### PR TITLE
Feature/schedule list

### DIFF
--- a/openjij/main.cpp
+++ b/openjij/main.cpp
@@ -127,7 +127,8 @@ PYBIND11_MODULE(cxxjij, m){
 		.def(py::init<const graph::Dense<double>&>(), "other"_a)
 		.def(py::init<const graph::Sparse<double>&>(), "other"_a)
 		.def(py::init<const graph::Sparse<double>&, graph::Spins&>(), "other"_a, "init_state"_a)
-		.def("simulated_annealing", &method::ClassicalIsing::simulated_annealing, "beta_min"_a, "beta_max"_a, "step_length"_a, "step_num"_a, "algo"_a="")
+		.def("simulated_annealing", (void (method::ClassicalIsing::*)(const double, const double, const size_t, const size_t, const std::string&)) &method::ClassicalIsing::simulated_annealing, "beta_min"_a, "beta_max"_a, "step_length"_a, "step_num"_a, "algo"_a="")
+		.def("simulated_annealing", (void (method::ClassicalIsing::*)(const std::vector<std::pair<double, size_t>>&, const std::string&)) &method::ClassicalIsing::simulated_annealing, "schedule"_a, "algo"_a="")
 		.def("get_spins", &method::ClassicalIsing::get_spins)
 		.def("initialize_spins", &method::ClassicalIsing::initialize_spins)
 		.def("set_spins", &method::ClassicalIsing::set_spins, "initial_state"_a);
@@ -137,7 +138,8 @@ PYBIND11_MODULE(cxxjij, m){
 		.def(py::init<const graph::Dense<double>&, size_t>(), "other"_a, "num_trotter_slices"_a)
 		.def(py::init<const graph::Sparse<double>&, size_t>(), "other"_a, "num_trotter_slices"_a)
 		.def(py::init<const graph::Sparse<double>&, size_t, graph::Spins&>(), "other"_a, "num_trotter_slices"_a, "init_state"_a)
-		.def("simulated_quantum_annealing", &method::QuantumIsing::simulated_quantum_annealing, "beta"_a, "gamma_min"_a, "gamma_max"_a, "step_length"_a, "step_num"_a, "algo"_a="")
+		.def("simulated_quantum_annealing", (void (method::QuantumIsing::*)(const double, const double, const double, const size_t, const size_t, const std::string&)) &method::QuantumIsing::simulated_quantum_annealing, "beta"_a, "gamma_min"_a, "gamma_max"_a, "step_length"_a, "step_num"_a, "algo"_a="")
+		.def("simulated_quantum_annealing", (void (method::QuantumIsing::*)(const double, const std::vector<std::pair<double, size_t>>&, const std::string&)) &method::QuantumIsing::simulated_quantum_annealing, "beta"_a, "schedule"_a, "algo"_a="")
 		.def("get_spins", &method::QuantumIsing::get_spins)
 		.def("initialize_spins", &method::QuantumIsing::initialize_spins)
 		.def("set_spins", &method::QuantumIsing::set_spins, "initial_state"_a);

--- a/src/algorithm/sa.cpp
+++ b/src/algorithm/sa.cpp
@@ -2,20 +2,30 @@
 #include <cmath>
 
 namespace openjij {
-	namespace algorithm {
+    namespace algorithm {
 
-		void SA::exec(updater::ClassicalUpdater& updater, const std::string& algo){
-			double r_beta = pow(beta_max/beta_min, 1.0/step_num);
-			double beta = beta_min;
-			//anneal
-			while(beta <= beta_max){
-				//step length -> number of MCS for each step
-				for(size_t i=0; i<step_length; i++){
-					//update
-					updater.update(beta, algo);
-				}
-				beta *= r_beta;
-			}
-		}
-	} // namespace algorithm
+        SA::SA(const Schedule& schedule):schedule(schedule){}
+
+        SA::SA(const double beta_min, const double beta_max, const size_t step_length, const size_t step_num) {
+            const double r_beta = std::pow(beta_max/beta_min, 1.0/step_num);
+            double beta = beta_min;
+            for (size_t i = 0; i < step_num; i++) {
+                schedule.emplace_back(std::make_pair(beta, step_length));
+                beta *= r_beta;
+            }
+        }
+
+        void SA::run(updater::ClassicalUpdater& updater, const std::string& algo) {
+            // anneal
+            for (const auto& elem : schedule) {
+                const double beta = elem.first;
+                const size_t step_length = elem.second;
+
+                // step length -> number of MCS for each step
+                for (size_t i = 0; i < step_length; i++) {
+                    updater.update(beta, algo);
+                }
+            }
+        }
+    } // namespace algorithm
 } // namespace openjij

--- a/src/algorithm/sa.h
+++ b/src/algorithm/sa.h
@@ -1,26 +1,28 @@
 #pragma once
+
 #include <string>
+#include <utility>
+#include <vector>
+
 #include "algorithm.h"
 #include "../updater/classical_updater.h"
 
 namespace openjij{
-	namespace algorithm{
-		using namespace openjij::updater;
+    namespace algorithm{
+        using namespace openjij::updater;
+        using Schedule = std::vector<std::pair<double, size_t>>;
 
-		//simulated annealing
-		class SA : public Algorithm{
-			private:
-				double beta_min;
-				double beta_max;
-				double step_length;
-				double step_num;
-			public:
-				//TODO: add annealing schedule option
-				SA(double beta_min, double beta_max, double step_length, size_t step_num)
-					:beta_min(beta_min), beta_max(beta_max), step_length(step_length), step_num(step_num){}
+        //simulated annealing
+        class SA : public Algorithm{
+            public:
+                SA(const Schedule& schedule);
+                SA(const double beta_min, const double beta_max, const size_t step_length, const size_t step_num);
 
-				//do SA protocol
-				void exec(ClassicalUpdater& updater, const std::string& algo = "");
-		};
-	}
+                // do SA protocol
+                void run(ClassicalUpdater& updater, const std::string& algo = "");
+
+            private:
+                Schedule schedule;
+        };
+    }
 }

--- a/src/algorithm/sqa.cpp
+++ b/src/algorithm/sqa.cpp
@@ -2,20 +2,36 @@
 #include <cmath>
 
 namespace openjij {
-	namespace algorithm {
+    namespace algorithm {
 
-		void SQA::exec(updater::QuantumUpdater& updater, const std::string& algo){
-			double r_g = pow(gamma_min/gamma_max, 1.0/step_num);
-			double gamma = gamma_max;
-			//anneal
-			while(gamma >= gamma_min){
-				//step length -> number of MCS for each step
-				for(size_t i=0; i<step_length; i++){
-					//update
-					updater.update(beta, gamma, algo);
-				}
-				gamma *= r_g;
-			}
-		}
-	} // namespace algorithm
+        SQA::SQA(const double beta, const Schedule& schedule)
+            :beta(beta), schedule(schedule) {
+        }
+
+        SQA::SQA(const double beta, const double gamma_min, const double gamma_max, const size_t step_length, const size_t step_num)
+            :beta(beta) {
+            const double r_gamma = std::pow(gamma_min/gamma_max, 1.0/step_num);
+            double gamma = gamma_max;
+
+            for (size_t i = 0; i < step_num; i++) {
+                schedule.emplace_back(std::make_pair(gamma, step_length));
+                gamma *= r_gamma;
+            }
+        }
+
+        void SQA::run(updater::QuantumUpdater& updater, const std::string& algo) {
+            // anneal
+            for (const auto& elem : schedule) {
+                const double gamma = elem.first;
+                const size_t step_length = elem.second;
+
+                // step length -> number of MCS for each step
+                for (size_t i = 0; i < step_length; i++) {
+                    // update
+                    updater.update(beta, gamma, algo);
+                }
+            }
+        }
+    } // namespace algorithm
 } // namespace openjij
+

--- a/src/algorithm/sqa.h
+++ b/src/algorithm/sqa.h
@@ -1,26 +1,29 @@
 #pragma once
+
 #include <string>
+#include <utility>
+#include <vector>
+
 #include "algorithm.h"
 #include "../updater/quantum_updater.h"
 
 namespace openjij{
-	namespace algorithm{
-		using namespace openjij::updater;
+    namespace algorithm{
+        using namespace openjij::updater;
+        using Schedule = std::vector<std::pair<double, size_t>>;
 
-		//simulated quantum annealing
-		class SQA : public Algorithm{
-			private:
-				double beta;
-				double gamma_min;
-				double gamma_max;
-				double step_length;
-				double step_num;
-			public:
-				SQA(double beta, double gamma_min, double gamma_max, double step_length, size_t step_num)
-					:beta(beta), gamma_min(gamma_min), gamma_max(gamma_max), step_length(step_length), step_num(step_num){}
+        //simulated quantum annealing
+        class SQA : public Algorithm{
+            public:
+                SQA(const double beta, const Schedule& schedule);
+                SQA(const double beta, const double gamma_min, const double gamma_max, const size_t step_length, const size_t step_num);
 
-				//do SQA protocol
-				void exec(QuantumUpdater& updater, const std::string& algo = "");
-		};
-	}
+                // do SQA protocol
+                void run(QuantumUpdater& updater, const std::string& algo = "");
+
+            private:
+                double beta;
+                Schedule schedule;
+        };
+    }
 }

--- a/src/method/classical_ising.cpp
+++ b/src/method/classical_ising.cpp
@@ -55,8 +55,14 @@ namespace openjij {
             return totaldE;
         }
 
-        void ClassicalIsing::simulated_annealing(const double beta_min, const double beta_max, const double step_length, const size_t step_num, const std::string& algo){
+        void ClassicalIsing::simulated_annealing(const double beta_min, const double beta_max, const size_t step_length, const size_t step_num, const std::string& algo){
             algorithm::SA sa(beta_min, beta_max, step_length, step_num);
+            //do simulated annealing
+            sa.run(*this, algo);
+        }
+
+        void ClassicalIsing::simulated_annealing(const Schedule& schedule, const std::string& algo) {
+            algorithm::SA sa(schedule);
             //do simulated annealing
             sa.run(*this, algo);
         }

--- a/src/method/classical_ising.cpp
+++ b/src/method/classical_ising.cpp
@@ -1,67 +1,68 @@
 #include "classical_ising.h"
 #include "../algorithm/sa.h"
+
 #include <cassert>
 #include <cmath>
 
 namespace openjij {
-	namespace method {
+    namespace method {
 
-		ClassicalIsing::ClassicalIsing(const graph::Dense<double>& interaction)
-			: spins(interaction.gen_spin()), interaction(interaction), urd{0.0, 1.0}{
-				//random number generator
-				std::random_device rd;
-				mt = std::mt19937(rd());
-				uid = std::uniform_int_distribution<>{0,(int)spins.size()-1};
-			}
+        ClassicalIsing::ClassicalIsing(const graph::Dense<double>& interaction)
+            : spins(interaction.gen_spin()), interaction(interaction), urd{0.0, 1.0}{
+                //random number generator
+                std::random_device rd;
+                mt = std::mt19937(rd());
+                uid = std::uniform_int_distribution<>{0,(int)spins.size()-1};
+            }
 
-		ClassicalIsing::ClassicalIsing(const graph::Dense<double>& interaction, graph::Spins& spins)
-			: spins(spins), interaction(interaction), urd{0.0, 1.0}{
-				//random number generator
-				std::random_device rd;
-				mt = std::mt19937(rd());
-				uid = std::uniform_int_distribution<>{0,(int)spins.size()-1};
-			}
+        ClassicalIsing::ClassicalIsing(const graph::Dense<double>& interaction, graph::Spins& spins)
+            : spins(spins), interaction(interaction), urd{0.0, 1.0}{
+                //random number generator
+                std::random_device rd;
+                mt = std::mt19937(rd());
+                uid = std::uniform_int_distribution<>{0,(int)spins.size()-1};
+            }
 
-		void ClassicalIsing::initialize_spins(){
-			spins = interaction.gen_spin();
-		}
-		void ClassicalIsing::set_spins(graph::Spins& initial_spins){
-			spins = initial_spins;
-		}
+        void ClassicalIsing::initialize_spins(){
+            spins = interaction.gen_spin();
+        }
+        void ClassicalIsing::set_spins(graph::Spins& initial_spins){
+            spins = initial_spins;
+        }
 
-		double ClassicalIsing::update(double beta, const std::string& algo){
-			double totaldE = 0;
-			size_t num_spins = spins.size();
+        double ClassicalIsing::update(const double beta, const std::string& algo){
+            double totaldE = 0;
+            size_t num_spins = spins.size();
 
-			if(algo == "single_spin_flip" or algo == ""){
-				//default updater (single_spin_flip)
-				for(size_t i=0; i<num_spins; i++){
-					size_t index = uid(mt);
-					//do metropolis
-					double dE = 0;
-					for(auto&& adj_index : interaction.adj_nodes(index)){
-						dE += -2 * spins[index] * (index != adj_index ? (interaction.J(index, adj_index) * spins[adj_index]) : interaction.h(index));
-					}
+            if(algo == "single_spin_flip" or algo == ""){
+                //default updater (single_spin_flip)
+                for(size_t i=0; i<num_spins; i++){
+                    size_t index = uid(mt);
+                    //do metropolis
+                    double dE = 0;
+                    for(auto&& adj_index : interaction.adj_nodes(index)){
+                        dE += -2 * spins[index] * (index != adj_index ? (interaction.J(index, adj_index) * spins[adj_index]) : interaction.h(index));
+                    }
 
-					//metropolis
-					if(exp(-beta*dE) > urd(mt)){
-						spins[index] *= -1;
-						totaldE += dE;
-					}
-				}
-			}
+                    //metropolis
+                    if(exp(-beta*dE) > urd(mt)){
+                        spins[index] *= -1;
+                        totaldE += dE;
+                    }
+                }
+            }
 
-			return totaldE;
-		}
+            return totaldE;
+        }
 
-		void ClassicalIsing::simulated_annealing(double beta_min, double beta_max, double step_length, size_t step_num, const std::string& algo){
-			algorithm::SA sa(beta_min, beta_max, step_length, step_num);
-			//do simulated annealing
-			sa.exec(*this, algo);
-		}
+        void ClassicalIsing::simulated_annealing(const double beta_min, const double beta_max, const double step_length, const size_t step_num, const std::string& algo){
+            algorithm::SA sa(beta_min, beta_max, step_length, step_num);
+            //do simulated annealing
+            sa.run(*this, algo);
+        }
 
-		const graph::Spins ClassicalIsing::get_spins() const{
-			return spins;
-		}
-	} // namespace method
+        const graph::Spins ClassicalIsing::get_spins() const{
+            return spins;
+        }
+    } // namespace method
 } // namespace openjij

--- a/src/method/classical_ising.h
+++ b/src/method/classical_ising.h
@@ -1,38 +1,40 @@
 #pragma once
+
+#include <random>
+
 #include "../graph/dense.h"
 #include "method.h"
 #include "../updater/classical_updater.h"
-#include <random>
 
 namespace openjij {
-	namespace method {
+    namespace method {
 
-		//TODO: double -> FloatType (template)
-		class ClassicalIsing : public Method, public updater::ClassicalUpdater{
-			//general classical ising model
-			private:
-				graph::Spins spins;
-				graph::Dense<double> interaction;
-				//random number generator
-				//TODO: use MT or xorshift
-				std::mt19937 mt;
-				std::uniform_int_distribution<> uid;
-				std::uniform_real_distribution<> urd;
+        //TODO: double -> FloatType (template)
+        class ClassicalIsing : public Method, public updater::ClassicalUpdater{
+            //general classical ising model
+            private:
+                graph::Spins spins;
+                graph::Dense<double> interaction;
+                //random number generator
+                //TODO: use MT or xorshift
+                std::mt19937 mt;
+                std::uniform_int_distribution<> uid;
+                std::uniform_real_distribution<> urd;
 
-			public:
-				ClassicalIsing(const graph::Dense<double>& interaction);
-				ClassicalIsing(const graph::Dense<double>& interaction, graph::Spins& spins);
+            public:
+                ClassicalIsing(const graph::Dense<double>& interaction);
+                ClassicalIsing(const graph::Dense<double>& interaction, graph::Spins& spins);
 
-				void initialize_spins();
-				void set_spins(graph::Spins& initial_spins);
+                void initialize_spins();
+                void set_spins(graph::Spins& initial_spins);
 
-				virtual double update(double beta, const std::string& algo = "") override;
+                virtual double update(const double beta, const std::string& algo = "") override;
 
-				//do simulated annelaing
-				void simulated_annealing(double beta_min, double beta_max, double step_length, size_t step_num, const std::string& algo = "");
+                //do simulated annelaing
+                void simulated_annealing(const double beta_min, const double beta_max, const double step_length, const size_t step_num, const std::string& algo = "");
 
-				const graph::Spins get_spins() const;
-		};
-	} // namespace method
+                const graph::Spins get_spins() const;
+        };
+    } // namespace method
 } // namespace openjij
 

--- a/src/method/classical_ising.h
+++ b/src/method/classical_ising.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <random>
+#include <utility>
+#include <vector>
 
 #include "../graph/dense.h"
 #include "method.h"
@@ -12,16 +14,9 @@ namespace openjij {
         //TODO: double -> FloatType (template)
         class ClassicalIsing : public Method, public updater::ClassicalUpdater{
             //general classical ising model
-            private:
-                graph::Spins spins;
-                graph::Dense<double> interaction;
-                //random number generator
-                //TODO: use MT or xorshift
-                std::mt19937 mt;
-                std::uniform_int_distribution<> uid;
-                std::uniform_real_distribution<> urd;
-
             public:
+                using Schedule = std::vector<std::pair<double, size_t>>;
+
                 ClassicalIsing(const graph::Dense<double>& interaction);
                 ClassicalIsing(const graph::Dense<double>& interaction, graph::Spins& spins);
 
@@ -31,9 +26,20 @@ namespace openjij {
                 virtual double update(const double beta, const std::string& algo = "") override;
 
                 //do simulated annelaing
-                void simulated_annealing(const double beta_min, const double beta_max, const double step_length, const size_t step_num, const std::string& algo = "");
+                void simulated_annealing(const double beta_min, const double beta_max, const size_t step_length, const size_t step_num, const std::string& algo = "");
+                void simulated_annealing(const Schedule& schedule, const std::string& algo = "");
 
                 const graph::Spins get_spins() const;
+
+            private:
+                graph::Spins spins;
+                graph::Dense<double> interaction;
+                //random number generator
+                //TODO: use MT or xorshift
+                std::mt19937 mt;
+                std::uniform_int_distribution<> uid;
+                std::uniform_real_distribution<> urd;
+
         };
     } // namespace method
 } // namespace openjij

--- a/src/method/quantum_ising.cpp
+++ b/src/method/quantum_ising.cpp
@@ -1,103 +1,104 @@
 #include "quantum_ising.h"
 #include "../algorithm/sqa.h"
+
 #include <cassert>
 #include <cmath>
 
 namespace openjij {
-	namespace method {
+    namespace method {
 
-		inline size_t QuantumIsing::mod_t(int64_t a) const{
-			//a -> [-1:num_trotter_slices]
-			//return a%num_trotter_slices (a>0), num_trotter_slices-1 (a==-1)
-			return (a+spins.size())%spins.size();
-		}
+        inline size_t QuantumIsing::mod_t(int64_t a) const{
+            //a -> [-1:num_trotter_slices]
+            //return a%num_trotter_slices (a>0), num_trotter_slices-1 (a==-1)
+            return (a+spins.size())%spins.size();
+        }
 
-		void QuantumIsing::initialize_spins(){
-			for (auto& elem : spins){
-				elem = interaction.gen_spin();
-			}
-		}
+        void QuantumIsing::initialize_spins(){
+            for (auto& elem : spins){
+                elem = interaction.gen_spin();
+            }
+        }
 
-		void QuantumIsing::set_spins(graph::Spins& initial_spin){
-			if(spins[0].size() != initial_spin.size()){
-				throw "Exception : spin size not match.";
-			}
-			for (auto& elem : spins){
-				elem = initial_spin;
-			}
-		}
+        void QuantumIsing::set_spins(graph::Spins& initial_spin){
+            if(spins[0].size() != initial_spin.size()){
+                throw "Exception : spin size not match.";
+            }
+            for (auto& elem : spins){
+                elem = initial_spin;
+            }
+        }
 
-		QuantumIsing::QuantumIsing(const graph::Dense<double>& interaction, size_t num_trotter_slices, graph::Spins& classical_spins)
-		:spins(num_trotter_slices), interaction(interaction), urd{0.0, 1.0}{
-			for(auto& elem : spins){
-				elem = classical_spins;
+        QuantumIsing::QuantumIsing(const graph::Dense<double>& interaction, size_t num_trotter_slices, graph::Spins& classical_spins)
+            :spins(num_trotter_slices), interaction(interaction), urd{0.0, 1.0}{
+                for(auto& elem : spins){
+                    elem = classical_spins;
 
-				//random number generators
-				std::random_device rd;
-				mt = std::mt19937(rd());
-				uid = std::uniform_int_distribution<>{0, (int)elem.size()-1};
-				uid_trotter = std::uniform_int_distribution<>{0, (int)num_trotter_slices-1};
-			}
-			assert(spins.size() != 0 and spins[0].size() != 0);
-		}
+                    //random number generators
+                    std::random_device rd;
+                    mt = std::mt19937(rd());
+                    uid = std::uniform_int_distribution<>{0, (int)elem.size()-1};
+                    uid_trotter = std::uniform_int_distribution<>{0, (int)num_trotter_slices-1};
+                }
+                assert(spins.size() != 0 and spins[0].size() != 0);
+            }
 
-		QuantumIsing::QuantumIsing(const graph::Dense<double>& interaction, size_t num_trotter_slices)
-			:spins(num_trotter_slices), interaction(interaction), urd{0.0, 1.0}{
-				//TODO: add exception
-				for(auto& elem : spins){
-					elem = interaction.gen_spin();
+        QuantumIsing::QuantumIsing(const graph::Dense<double>& interaction, size_t num_trotter_slices)
+            :spins(num_trotter_slices), interaction(interaction), urd{0.0, 1.0}{
+                //TODO: add exception
+                for(auto& elem : spins){
+                    elem = interaction.gen_spin();
 
-					//random number generators
-					std::random_device rd;
-					mt = std::mt19937(rd());
-					uid = std::uniform_int_distribution<>{0, (int)elem.size()-1};
-					uid_trotter = std::uniform_int_distribution<>{0, (int)num_trotter_slices-1};
-				}
-				assert(spins.size() != 0 and spins[0].size() != 0);
-			}
+                    //random number generators
+                    std::random_device rd;
+                    mt = std::mt19937(rd());
+                    uid = std::uniform_int_distribution<>{0, (int)elem.size()-1};
+                    uid_trotter = std::uniform_int_distribution<>{0, (int)num_trotter_slices-1};
+                }
+                assert(spins.size() != 0 and spins[0].size() != 0);
+            }
 
-		double QuantumIsing::update(double beta, double gamma, const std::string& algo){
-			double totaldE = 0;
-			size_t num_classical_spins = spins[0].size();
-			size_t num_trotter_slices = spins.size();
+        double QuantumIsing::update(const double beta, const double gamma, const std::string& algo){
+            double totaldE = 0;
+            size_t num_classical_spins = spins[0].size();
+            size_t num_trotter_slices = spins.size();
 
-			if(algo == "single_spin_flip" or algo == ""){
-				//default updater (single_spin_flip)
-				for(size_t i=0; i<num_classical_spins*num_trotter_slices; i++){
-					size_t index_trot = uid_trotter(mt);
-					size_t index = uid(mt);
-					//do metropolis
-					double dE = 0;
-					//adjacent nodes
-					for(auto&& adj_index : interaction.adj_nodes(index)){
-						dE += -2 * (beta/num_trotter_slices) * spins[index_trot][index] * (index != adj_index ? (interaction.J(index, adj_index) * spins[index_trot][adj_index]) : interaction.h(index));
-					}
+            if(algo == "single_spin_flip" or algo == ""){
+                //default updater (single_spin_flip)
+                for(size_t i=0; i<num_classical_spins*num_trotter_slices; i++){
+                    size_t index_trot = uid_trotter(mt);
+                    size_t index = uid(mt);
+                    //do metropolis
+                    double dE = 0;
+                    //adjacent nodes
+                    for(auto&& adj_index : interaction.adj_nodes(index)){
+                        dE += -2 * (beta/num_trotter_slices) * spins[index_trot][index] * (index != adj_index ? (interaction.J(index, adj_index) * spins[index_trot][adj_index]) : interaction.h(index));
+                    }
 
-					//trotter direction
-					dE += -2 * (1/2.) * log(tanh(beta*gamma/num_trotter_slices)) * spins[index_trot][index]*(spins[mod_t((int64_t)index_trot+1)][index] + spins[mod_t((int64_t)index_trot-1)][index]);
+                    //trotter direction
+                    dE += -2 * (1/2.) * log(tanh(beta*gamma/num_trotter_slices)) * spins[index_trot][index]*(spins[mod_t((int64_t)index_trot+1)][index] + spins[mod_t((int64_t)index_trot-1)][index]);
 
 
-					//metropolis 
-					if(exp(-dE) > urd(mt)){
-						spins[index_trot][index] *= -1;
-						totaldE += dE;
-					}
+                    //metropolis 
+                    if(exp(-dE) > urd(mt)){
+                        spins[index_trot][index] *= -1;
+                        totaldE += dE;
+                    }
 
-				}
-			}
+                }
+            }
 
-			return totaldE;
-		}
+            return totaldE;
+        }
 
-		void QuantumIsing::simulated_quantum_annealing(double beta, double gamma_min, double gamma_max, double step_length, size_t step_num, const std::string& algo){
-			algorithm::SQA sqa(beta, gamma_min, gamma_max, step_length, step_num);
-			//do simulated quantum annealing
-			sqa.exec(*this, algo);
-		}
+        void QuantumIsing::simulated_quantum_annealing(const double beta, const double gamma_min, const double gamma_max, const size_t step_length, const size_t step_num, const std::string& algo) {
+            algorithm::SQA sqa(beta, gamma_min, gamma_max, step_length, step_num);
+            //do simulated quantum annealing
+            sqa.run(*this, algo);
+        }
 
-		TrotterSpins QuantumIsing::get_spins() const{
-			return this->spins;
-		}
+        TrotterSpins QuantumIsing::get_spins() const{
+            return this->spins;
+        }
 
-	} // namespace method
+    } // namespace method
 } // namespace openjij

--- a/src/method/quantum_ising.cpp
+++ b/src/method/quantum_ising.cpp
@@ -96,6 +96,12 @@ namespace openjij {
             sqa.run(*this, algo);
         }
 
+        void QuantumIsing::simulated_quantum_annealing(const double beta, const Schedule& schedule, const std::string& algo) {
+            algorithm::SQA sqa(beta, schedule);
+            //do simulated quantum annealing
+            sqa.run(*this, algo);
+        }
+
         TrotterSpins QuantumIsing::get_spins() const{
             return this->spins;
         }

--- a/src/method/quantum_ising.h
+++ b/src/method/quantum_ising.h
@@ -1,44 +1,50 @@
 #pragma once
+
+#include <random>
+#include <utility>
+#include <vector>
+
 #include "../graph/dense.h"
 #include "method.h"
 #include "../updater/quantum_updater.h"
-#include <random>
 
 namespace openjij {
-	namespace method {
+    namespace method {
 
-		//TODO: double -> FloatType (template)
-		class QuantumIsing : public Method, public updater::QuantumUpdater{
-			//general transverse-field ising model with discrete trotter slices
+        //TODO: double -> FloatType (template)
+        class QuantumIsing : public Method, public updater::QuantumUpdater{
+            //general transverse-field ising model with discrete trotter slices
 
-			private:
-				TrotterSpins spins; //spins with trotter slices
-				graph::Dense<double> interaction; //original interaction
+            private:
+                TrotterSpins spins; //spins with trotter slices
+                graph::Dense<double> interaction; //original interaction
 
-				//random number generators
-				//TODO: use MT or xorshift?
-				std::mt19937 mt;
-				std::uniform_int_distribution<> uid;
-				std::uniform_int_distribution<> uid_trotter;
-				std::uniform_real_distribution<> urd;
+                //random number generators
+                //TODO: use MT or xorshift?
+                std::mt19937 mt;
+                std::uniform_int_distribution<> uid;
+                std::uniform_int_distribution<> uid_trotter;
+                std::uniform_real_distribution<> urd;
 
-				//mod function for dealing trotter indices
-				inline size_t mod_t(int64_t a) const;
+                //mod function for dealing trotter indices
+                inline size_t mod_t(int64_t a) const;
 
-			public:
-				QuantumIsing(const graph::Dense<double>& interaction, size_t num_trotter_slices);
-				QuantumIsing(const graph::Dense<double>& interaction, size_t num_trotter_slices, graph::Spins& classical_spins);
+            public:
+                using Schedule = std::vector<std::pair<double, size_t>>;
 
-				void initialize_spins();
-				void set_spins(graph::Spins& initial_spin);
+                QuantumIsing(const graph::Dense<double>& interaction, size_t num_trotter_slices);
+                QuantumIsing(const graph::Dense<double>& interaction, size_t num_trotter_slices, graph::Spins& classical_spins);
 
-				virtual double update(double beta, double gamma, const std::string& algo = "") override;
+                void initialize_spins();
+                void set_spins(graph::Spins& initial_spin);
 
-				void simulated_quantum_annealing(double beta, double gamma_min, double gamma_max, double step_length, size_t step_num, const std::string& algo = "");
+                virtual double update(const double beta, const double gamma, const std::string& algo = "") override;
 
-				TrotterSpins get_spins() const;
+                void simulated_quantum_annealing(const double beta, const double gamma_min, const double gamma_max, const size_t step_length, const size_t step_num, const std::string& algo = "");
 
-		};
-	} // namespace method
+                TrotterSpins get_spins() const;
+
+        };
+    } // namespace method
 } // namespace openjij
 

--- a/src/method/quantum_ising.h
+++ b/src/method/quantum_ising.h
@@ -14,6 +14,21 @@ namespace openjij {
         //TODO: double -> FloatType (template)
         class QuantumIsing : public Method, public updater::QuantumUpdater{
             //general transverse-field ising model with discrete trotter slices
+            public:
+                using Schedule = std::vector<std::pair<double, size_t>>;
+
+                QuantumIsing(const graph::Dense<double>& interaction, size_t num_trotter_slices);
+                QuantumIsing(const graph::Dense<double>& interaction, size_t num_trotter_slices, graph::Spins& classical_spins);
+
+                void initialize_spins();
+                void set_spins(graph::Spins& initial_spin);
+
+                virtual double update(const double beta, const double gamma, const std::string& algo = "") override;
+
+                void simulated_quantum_annealing(const double beta, const double gamma_min, const double gamma_max, const size_t step_length, const size_t step_num, const std::string& algo = "");
+                void simulated_quantum_annealing(const double beta, const Schedule& schedule, const std::string& algo = "");
+
+                TrotterSpins get_spins() const;
 
             private:
                 TrotterSpins spins; //spins with trotter slices
@@ -28,22 +43,6 @@ namespace openjij {
 
                 //mod function for dealing trotter indices
                 inline size_t mod_t(int64_t a) const;
-
-            public:
-                using Schedule = std::vector<std::pair<double, size_t>>;
-
-                QuantumIsing(const graph::Dense<double>& interaction, size_t num_trotter_slices);
-                QuantumIsing(const graph::Dense<double>& interaction, size_t num_trotter_slices, graph::Spins& classical_spins);
-
-                void initialize_spins();
-                void set_spins(graph::Spins& initial_spin);
-
-                virtual double update(const double beta, const double gamma, const std::string& algo = "") override;
-
-                void simulated_quantum_annealing(const double beta, const double gamma_min, const double gamma_max, const size_t step_length, const size_t step_num, const std::string& algo = "");
-
-                TrotterSpins get_spins() const;
-
         };
     } // namespace method
 } // namespace openjij

--- a/src/updater/classical_updater.h
+++ b/src/updater/classical_updater.h
@@ -1,13 +1,14 @@
 #pragma once
 #include "updater.h"
+
 #include <string>
 
 namespace openjij {
-	namespace updater {
-		class ClassicalUpdater : public Updater{
-			public:
-				//beta -> inverse temperature
-				virtual double update(double beta, const std::string& algo = "") = 0;
-		};
-	} // namespace updater
+    namespace updater {
+        class ClassicalUpdater : public Updater{
+            public:
+                // beta -> inverse temperature
+                virtual double update(const double beta, const std::string& algo = "") = 0;
+        };
+    } // namespace updater
 } // namespace openjij

--- a/src/updater/quantum_updater.h
+++ b/src/updater/quantum_updater.h
@@ -1,14 +1,15 @@
 #pragma once
 #include "updater.h"
+
 #include <string>
 
 namespace openjij {
-	namespace updater {
-		class QuantumUpdater : public Updater{
-			public:
-				//beta -> inverse temperature
-				//gamma -> transverse field
-				virtual double update(double beta, double gamma, const std::string& algo = "") = 0;
-		};
-	} // namespace updater
+    namespace updater {
+        class QuantumUpdater : public Updater{
+            public:
+                // beta -> inverse temperature
+                // gamma -> transverse field
+                virtual double update(const double beta, const double gamma, const std::string& algo = "") = 0;
+        };
+    } // namespace updater
 } // namespace openjij


### PR DESCRIPTION
I added the feature; set inverse temperature (SA) & transverse field (QSA) schedule to a list.
You can use both previous `simulated_/quantum_/annealing(const double, ...)` and new `simulated_/quantum_/annealing(schedule, ...)`.

The schedule list is composed of `std::vector<std::pair<double, size_t>>`.
You can write schedule lists as following;
```cpp
using Schedule = std::vector<std::pair<double /* beta or h */, size_t /* # MCS for each step */>>;
Schedule schedule;
schedule.emplace_back(std::make_pair(0.5, 1));
schedule.emplace_back(std::make_pair(1.5, 2));```