### PR TITLE
fix patch for sample_qubo with sparse

### DIFF
--- a/openjij/utils/graph_utils.py
+++ b/openjij/utils/graph_utils.py
@@ -8,7 +8,7 @@ def qubo_to_ising(mat: np.ndarray):
 
     """
     mat /= 4
-    for i in range(len(mat)):
+    for i in range(mat.shape[0]):
         mat[i, i] += np.sum(mat[i, :])
     
 


### PR DESCRIPTION
* fix error which occurs with `sample_qubo` and sparse graph