### PR TITLE
Fix sample_hubo() bug

### DIFF
--- a/src/graph/json/parse.hpp
+++ b/src/graph/json/parse.hpp
@@ -74,6 +74,11 @@ inline auto json_parse_polynomial(const nlohmann::json& obj, const bool relabel 
    
    const std::size_t num_variables    = obj["variables"].size();
    const int64_t num_interactions = static_cast<int64_t>(obj["poly_value_list"].size());
+   
+   if (num_interactions == 0) {
+      throw std::runtime_error("The interaction is empty.");
+   }
+   
    const cimod::PolynomialKeyList<std::size_t> &poly_key_distance_list = obj["poly_key_distance_list"];
    const cimod::PolynomialValueList<FloatType> &poly_value_list        = obj["poly_value_list"];
    cimod::PolynomialKeyList<Index> poly_key_list(num_interactions);

--- a/src/system/classical_ising_polynomial.hpp
+++ b/src/system/classical_ising_polynomial.hpp
@@ -85,6 +85,12 @@ public:
       if (poly_key_list.size() != poly_value_list.size()) {
          throw std::runtime_error("The sizes of key_list and value_list must match each other");
       }
+      if (poly_key_list.size() == 0) {
+         throw std::runtime_error("The interaction is empty.");
+      }
+      if (num_variables == 0) {
+         throw std::runtime_error("The number of variables is zero.");
+      }
       
       num_interactions_ = static_cast<int64_t>(poly_key_list.size());
       
@@ -357,6 +363,10 @@ private:
          throw std::runtime_error("The sizes of key_list and value_list must match each other");
       }
 
+      if (poly_key_list.size() == 0) {
+         throw std::runtime_error("The interaction is empty.");
+      }
+      
       std::unordered_set<graph::Index> active_variable_set;
       
       poly_key_list_.clear();

--- a/src/system/k_local_polynomial.hpp
+++ b/src/system/k_local_polynomial.hpp
@@ -66,6 +66,9 @@ public:
       if (poly_key_list.size() != poly_value_list.size()) {
          throw std::runtime_error("The sizes of key_list and value_list must match each other");
       }
+      if (poly_key_list.size() == 0) {
+         throw std::runtime_error("The interaction is empty.");
+      }
 
       std::unordered_set<graph::Index> active_binary_set;
       
@@ -107,6 +110,9 @@ public:
       
       if (poly_key_list.size() != poly_value_list.size()) {
          throw std::runtime_error("The sizes of key_list and value_list must match each other");
+      }
+      if (poly_key_list.size() == 0) {
+         throw std::runtime_error("The interaction is empty.");
       }
       
       num_interactions_ = static_cast<int64_t>(poly_key_list.size());


### PR DESCRIPTION
Befor
```
import openjij
openjij.SASampler().sample_hubo({}, "SPIN")
zsh: segmentation fault  python
```

After
```
import openjij
openjij.SASampler().sample_hubo({}, "SPIN")
RuntimeError: The interaction is empty.
```