### PR TITLE
Hotfix/vartype

### DIFF
--- a/openjij/declare.hpp
+++ b/openjij/declare.hpp
@@ -233,7 +233,6 @@ inline void declare_ClassicalIsingPolynomial(py::module &m, const std::string& g
    .def(py::init<const graph::Spins&, const GraphType&, const cimod::Vartype>(), "init_variables"_a, "init_interaction"_a, "vartype"_a)
    .def(py::init<const graph::Spins&, const GraphType&, const std::string   >(), "init_variables"_a, "init_interaction"_a, "vartype"_a)
    .def(py::init([](const graph::Spins& init_spins, const py::object& obj){return std::unique_ptr<CIP>(new CIP(init_spins, static_cast<nlohmann::json>(obj)));}),"init_spin"_a, "obj"_a)
-   .def_readonly("vartype"      , &CIP::vartype      )
    .def_readonly("variables"    , &CIP::variables    )
    .def_readonly("num_variables", &CIP::num_variables)
    .def("reset_variables"       , &CIP::reset_variables, "init_variables"_a)

--- a/openjij/main.cpp
+++ b/openjij/main.cpp
@@ -26,8 +26,6 @@
 PYBIND11_MODULE(cxxjij, m){
    m.doc() = "openjij is a framework for ising and qubo";
 
-   py::module_::import("cxxcimod");
-
    /**********************************************************
     //namespace graph
     **********************************************************/
@@ -130,9 +128,6 @@ PYBIND11_MODULE(cxxjij, m){
    
    m_utility.def("make_transverse_field_schedule_list", &openjij::utility::make_transverse_field_schedule_list,
                  "beta"_a, "one_mc_step"_a, "num_call_updater"_a);
-   
-   
-   
    
    /**********************************************************
     //namespace result

--- a/openjij/main.cpp
+++ b/openjij/main.cpp
@@ -25,7 +25,9 @@
 
 PYBIND11_MODULE(cxxjij, m){
    m.doc() = "openjij is a framework for ising and qubo";
-   
+
+   py::module_::import("cxxcimod");
+
    /**********************************************************
     //namespace graph
     **********************************************************/

--- a/src/result/get_solution.hpp
+++ b/src/result/get_solution.hpp
@@ -41,7 +41,7 @@ const graph::Spins get_solution(const system::ClassicalIsing<GraphType>& system)
    //convert from Eigen::Vector to std::vector
    graph::Spins ret_spins(system.num_spins);
    for(std::size_t i=0; i<system.num_spins; i++){
-      ret_spins[i] = system.spin(i)*system.spin(system.num_spins);
+      ret_spins[i] = static_cast<graph::Spin>(system.spin(i)*system.spin(system.num_spins));
    }
    return ret_spins;
 }
@@ -75,7 +75,7 @@ const graph::Spins get_solution(const system::TransverseIsing<GraphType>& system
    //convert from Eigen::Vector to std::vector
    graph::Spins ret_spins(system.num_classical_spins);
    for(std::size_t i=0; i<system.num_classical_spins; i++){
-      ret_spins[i] = spins(i, minimum_trotter);
+      ret_spins[i] = static_cast<graph::Spin>(spins(i, minimum_trotter));
    }
    return ret_spins;
 }

--- a/src/system/transverse_ising.hpp
+++ b/src/system/transverse_ising.hpp
@@ -66,7 +66,7 @@ namespace openjij {
                  * @param init_trotter_spins
                  * @param init_interaction
                  */
-                TransverseIsing(const TrotterSpins& init_trotter_spins, const graph::Dense<FloatType>& init_interaction, double gamma)
+                TransverseIsing(const TrotterSpins& init_trotter_spins, const graph::Dense<FloatType>& init_interaction, const FloatType gamma)
                 : trotter_spins(utility::gen_matrix_from_trotter_spins<FloatType, Eigen::ColMajor>(init_trotter_spins)),
                 interaction(init_interaction.get_interactions()),
                 num_classical_spins(init_trotter_spins[0].size()), gamma(gamma){
@@ -88,7 +88,7 @@ namespace openjij {
                  * @param init_interaction
                  * @param num_trotter_slices
                  */
-                TransverseIsing(const graph::Spins& init_classical_spins, const graph::Dense<FloatType>& init_interaction, double gamma, size_t num_trotter_slices)
+                TransverseIsing(const graph::Spins& init_classical_spins, const graph::Dense<FloatType>& init_interaction, const FloatType gamma, const size_t num_trotter_slices)
                 :interaction(init_interaction.get_interactions()),
                  num_classical_spins(init_classical_spins.size()), gamma(gamma){
                     //initialize trotter_spins with classical_spins
@@ -233,7 +233,7 @@ namespace openjij {
                  * @param init_trotter_spins
                  * @param init_interaction
                  */
-                TransverseIsing(const TrotterSpins& init_trotter_spins, const graph::Sparse<FloatType>& init_interaction, double gamma)
+                TransverseIsing(const TrotterSpins& init_trotter_spins, const graph::Sparse<FloatType>& init_interaction, FloatType gamma)
                 :trotter_spins(utility::gen_matrix_from_trotter_spins<FloatType, Eigen::ColMajor>(init_trotter_spins)),
                 interaction(utility::gen_matrix_from_graph<Eigen::RowMajor>(init_interaction)),
                 num_classical_spins(init_trotter_spins[0].size()), gamma(gamma){
@@ -255,7 +255,7 @@ namespace openjij {
                  * @param init_interaction
                  * @param num_trotter_slices
                  */
-                TransverseIsing(const graph::Spins& init_classical_spins, const graph::Sparse<FloatType>& init_interaction, double gamma, size_t num_trotter_slices)
+                TransverseIsing(const graph::Spins& init_classical_spins, const graph::Sparse<FloatType>& init_interaction, const FloatType gamma, const size_t num_trotter_slices)
                 :interaction(utility::gen_matrix_from_graph<Eigen::RowMajor>(init_interaction)),
                 num_classical_spins(init_classical_spins.size()), gamma(gamma){
                     //initialize trotter_spins with classical_spins
@@ -337,7 +337,7 @@ namespace openjij {
                 }
 
 
-                inline static std::size_t mod_t(std::int64_t a, std::size_t num_trotter_slices){
+                inline static std::size_t mod_t(const std::int64_t a, const std::size_t num_trotter_slices){
                     //a -> [-1:num_trotter_slices]
                     //return a%num_trotter_slices (a>0), num_trotter_slices-1 (a==-1)
                     return (a+num_trotter_slices)%num_trotter_slices;
@@ -386,7 +386,7 @@ namespace openjij {
          * @return generated object
          */
         template<typename GraphType>
-            auto make_transverse_ising(const TrotterSpins& init_trotter_spins, const GraphType& init_interaction, double gamma){
+            auto make_transverse_ising(const TrotterSpins& init_trotter_spins, const GraphType& init_interaction, const typename GraphType::value_type gamma){
                 return TransverseIsing<GraphType>(init_trotter_spins, init_interaction, gamma);
             }
 
@@ -402,7 +402,7 @@ namespace openjij {
          * @return generated object
          */
         template<typename GraphType>
-            auto make_transverse_ising(const graph::Spins& classical_spins, const GraphType& init_interaction, double gamma, std::size_t num_trotter_slices){
+            auto make_transverse_ising(const graph::Spins& classical_spins, const GraphType& init_interaction, const typename GraphType::value_type gamma, const std::size_t num_trotter_slices){
                 return TransverseIsing<GraphType>(classical_spins, init_interaction, gamma, num_trotter_slices);
             }
     } // namespace system


### PR DESCRIPTION
## Changes

**Fixed `vartype` problem.**
One cannot access vartype. The following code

```
import cxxjij
model = cxxjij.graph.Polynomial(3)
model[0,1,2] = 1
sys = cxxjij.system.make_classical_ising_polynomial([1,1,1], model, "SPIN")
sys.vartype
```
raises
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'cxxjij.system.ClassicalIsing_Polynomial' object has no attribute 'vartype'
```

Instead, one can use `get_vartype_to_string()` function like
```
import cxxjij
model = cxxjij.graph.Polynomial(3)
model[0,1,2] = 1
sys = cxxjij.system.make_classical_ising_polynomial([1,1,1], model, "SPIN")
sys.get_vartype_to_string()
'SPIN'
```


## Related issue

* https://github.com/OpenJij/OpenJij/issues/225#issue-1047069402

## Destructive changes

One cannot access `vartype` from the polynomial system class.
(To begin with, the access of `vartype` raised error before)

## Other Changes

* Silence implicit conversion warnings

