### PR TITLE
Hotfix/initial state

### DIFF
--- a/openjij/sampler/sa_sampler.py
+++ b/openjij/sampler/sa_sampler.py
@@ -227,9 +227,41 @@ class SASampler(BaseSampler):
         if initial_state is None:
             def _generate_init_state(): return ising_graph.gen_spin(seed) if seed != None else ising_graph.gen_spin()
         else:
+            temp_initial_state = []
             if isinstance(initial_state, dict):
-                initial_state = [initial_state[k] for k in model.variables]
-            _init_state = np.array(initial_state)
+                if model.vartype == openjij.BINARY:
+                    for k in model.variables:
+                        v = initial_state[k]
+                        if v != 0 and v != 1:
+                            raise RuntimeError("The initial variables must be 0 or 1.")
+                        temp_initial_state.append(2*v - 1)
+                elif model.vartype == openjij.SPIN:
+                    for k in model.variables:
+                        v = initial_state[k]
+                        if v != -1 and v != 1:
+                            raise RuntimeError("The initial variables must be -1 or +1.")
+                        temp_initial_state.append(v)
+                else:
+                    raise RuntimeError("Unknown vartype detected.")
+            elif isinstance(initial_state, (list, tuple)):
+                if model.vartype == openjij.BINARY:
+                    for k in range(len(model.variables)):
+                        v = initial_state[k]
+                        if v != 0 and v != 1:
+                            raise RuntimeError("The initial variables must be 0 or 1.")
+                        temp_initial_state.append(2*v - 1)
+                elif model.vartype == openjij.SPIN:
+                    for k in range(len(model.variables)):
+                        v = initial_state[k]
+                        if v != -1 and v != 1:
+                            raise RuntimeError("The initial variables must be -1 or +1.")
+                        temp_initial_state.append(v)
+                else:
+                    raise RuntimeError("Unknown vartype detected.")
+            else:
+                raise RuntimeError("Unsupported type of initial_state.")
+
+            _init_state = np.array(temp_initial_state)
 
             # validate initial_state size
             if len(initial_state) != ising_graph.size():

--- a/src/system/classical_ising.hpp
+++ b/src/system/classical_ising.hpp
@@ -24,6 +24,7 @@
 #include <Eigen/Dense>
 #include <Eigen/Sparse>
 
+#include <graph/cimod/src/utilities.hpp>
 
 namespace openjij {
     namespace system {
@@ -61,6 +62,7 @@ namespace openjij {
                     : spin(utility::gen_vector_from_std_vector<FloatType, Eigen::ColMajor>(init_spin)),
                     interaction(init_interaction.get_interactions()),
                     num_spins(init_interaction.get_num_spins()){
+                        cimod::CheckVariables(init_spin, cimod::Vartype::SPIN);
                         assert(init_spin.size() == init_interaction.get_num_spins());
                         reset_dE();
                     }

--- a/src/system/classical_ising_polynomial.hpp
+++ b/src/system/classical_ising_polynomial.hpp
@@ -53,7 +53,7 @@ public:
    //! @param poly_graph graph::Polynomial<FloatType>& (Polynomial graph class). The initial interacrtions.
    //! @param init_vartype const cimod::Vartype. The model's variable type. SPIN or BINARY.
    ClassicalIsingPolynomial(const graph::Spins &init_variables, const graph::Polynomial<FloatType> &poly_graph, const cimod::Vartype init_vartype): num_variables(poly_graph.size()), variables(init_variables), vartype(init_vartype) {
-      CheckVariables(variables);
+      cimod::CheckVariables(variables, vartype);
       SetInteractions(poly_graph);
       SetAdj();
       ResetZeroCount();
@@ -68,7 +68,7 @@ public:
    //! @param poly_graph graph::Polynomial<FloatType>& (Polynomial graph class). The initial interacrtions.
    //! @param init_vartype const std::string. The model's variable type. "SPIN" or "BINARY".
    ClassicalIsingPolynomial(const graph::Spins &init_variables, const graph::Polynomial<FloatType> &poly_graph, const std::string init_vartype): num_variables(poly_graph.size()), variables(init_variables), vartype(ConvertVartype(init_vartype)) {
-      CheckVariables(variables);
+      cimod::CheckVariables(variables, vartype);
       SetInteractions(poly_graph);
       SetAdj();
       ResetZeroCount();
@@ -82,7 +82,7 @@ public:
    //! @param init_variables graph::Spins& or graph::Binaries& (both are equal). The initial spin/binary configurations.
    //! @param j const nlohmann::json object
    ClassicalIsingPolynomial(const graph::Spins &init_variables, const nlohmann::json &j):num_variables(init_variables.size()), variables(init_variables), vartype(j.at("vartype") == "SPIN" ? cimod::Vartype::SPIN: cimod::Vartype::BINARY) {
-      CheckVariables(variables);
+      cimod::CheckVariables(variables, vartype);
       const auto &v_k_v = graph::json_parse_polynomial<FloatType>(j);
       const auto &poly_key_list   = std::get<0>(v_k_v);
       const auto &poly_value_list = std::get<1>(v_k_v);
@@ -125,7 +125,7 @@ public:
       if (init_variables.size() != variables.size()) {
          throw std::runtime_error("The size of initial spins/binaries does not equal to system size");
       }
-      CheckVariables(init_variables);
+      cimod::CheckVariables(init_variables, vartype);
       if (vartype == cimod::Vartype::SPIN) {
          for (const auto &index_variable: active_variables_) {
             if (variables[index_variable] != init_variables[index_variable]) {
@@ -422,29 +422,7 @@ private:
          throw std::runtime_error("Unknown vartype detected");
       }
    }
-   
-   //! @brief Check if variables are valid
-   //! @param init_variables const graph::Spins&
-   void CheckVariables(const graph::Spins &init_variables) const {
-      if (vartype == cimod::Vartype::SPIN) {
-         for (const auto &v: init_variables) {
-            if (!(v == -1 || v == +1)) {
-               throw std::runtime_error("The initial variables must be -1 or +1");
-            }
-         }
-      }
-      else if (vartype == cimod::Vartype::BINARY) {
-         for (const auto &v: init_variables) {
-            if (!(v == 0 || v == 1)) {
-               throw std::runtime_error("The initial variables must be 0 or 1");
-            }
-         }
-      }
-      else {
-         throw std::runtime_error("Unknown vartype detected");
-      }
-   }
-   
+      
    //! @brief Return the key and value of the absolute maximum interaction.
    //! @return The key and value of the absolute maximum interaction as std::pair.
    std::pair<std::vector<graph::Index>, FloatType> FindMaxInteraction() const {

--- a/src/system/k_local_polynomial.hpp
+++ b/src/system/k_local_polynomial.hpp
@@ -59,7 +59,7 @@ public:
    //! @param poly_graph const graph::Polynomial<FloatType>& (Polynomial graph class). The initial interacrtions.
    KLocalPolynomial(const graph::Binaries &init_binaries, const graph::Polynomial<FloatType> &poly_graph): num_binaries(init_binaries.size()), binaries(init_binaries), binaries_v_(init_binaries) {
       
-      CheckVariables(binaries);
+      cimod::CheckVariables(binaries, vartype);
 
       const auto &poly_key_list   = poly_graph.get_keys();
       const auto &poly_value_list = poly_graph.get_values();
@@ -101,7 +101,7 @@ public:
    //! @param j const nlohmann::json&
    KLocalPolynomial(const graph::Binaries &init_binaries, const nlohmann::json &j) :num_binaries(init_binaries.size()), binaries(init_binaries), binaries_v_(init_binaries) {
       
-      CheckVariables(binaries);
+      cimod::CheckVariables(binaries, vartype);
       
       if (j.at("vartype") != "BINARY") {
          throw std::runtime_error("Only binary variables are supported");
@@ -144,7 +144,7 @@ public:
    //! @param init_binaries const graph::Binaries&
    void reset_binaries(const graph::Binaries &init_binaries) {
       
-      CheckVariables(init_binaries);
+      cimod::CheckVariables(init_binaries, vartype);
       
       if (init_binaries.size() != binaries.size()) {
          throw std::runtime_error("The size of initial binaries does not equal to system size");
@@ -546,16 +546,6 @@ private:
          }
          zero_count_[i]   = zero_count;
          zero_count_v_[i] = zero_count;
-      }
-   }
-   
-   //! @brief Check if variables are valid
-   //! @param init_binaries const graph::Spins&
-   void CheckVariables(const graph::Binaries &init_binaries) const {
-      for (const auto &v: init_binaries) {
-         if (!(v == 0 || v == 1)) {
-            throw std::runtime_error("The initial binaries must be 0 or 1");
-         }
       }
    }
    


### PR DESCRIPTION
## Changes

* Fix initial state problem: https://github.com/OpenJij/OpenJij/issues/231#issue-1089793532

### Before Changes
### Case 1
```python
import openjij as oj
res = oj.SASampler().sample_qubo({(0,1):-1}, initial_state=[0,1])
res.states
array([[0, 1]], dtype=int8)
```
[0, 1] is not the ground state [1, 1]  

### Case 2
```python
import openjij as oj
res = oj.SASampler().sample_ising({}, {(0,1):-1}, initial_state=[0,10])
res.states
array([[-1, 10]], dtype=int8)
```
The above code should raise error.

### After Changes
### Case 1
```python
import openjij as oj
res = oj.SASampler().sample_qubo({(0,1):-1}, initial_state=[0,1])
res.states
array([[1, 1]], dtype=int8)
```
[1, 1] is the ground state.

### Case 2
```python
import openjij as oj
res = oj.SASampler().sample_ising({}, {(0,1):-1}, initial_state=[0,10])
RuntimeError: The initial variables must be -1 or +1.
```
