### PR TITLE
フロントページのHUBOハミルトニアンの中にあったKatexの文字を消しました。

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -97,7 +97,6 @@ print(response)
 If you want to handle higher order model as follows:    
 ```{math}
 H = \sum_{i}h_i\sigma_i + \sum_{i < j} J_{ij} \sigma_i \sigma_j + \sum_{i, j, k} K_{i,j,k} \sigma_i\sigma_j \sigma_k \cdots \\
-\KaTeX 
 ``` 
 
 use `.sample_hubo`


### PR DESCRIPTION
## Changes

下の画像のようにフロントページで、HUBOハミルトニアンの中にKatexの文字があったので、それを削除しました

![HUBO](https://user-images.githubusercontent.com/48146319/194483069-ca6e25c5-ed8d-477b-ad4b-2022542a4570.png)
