### PR TITLE
Remove params setting options from constructors of samplers

### DIFF
--- a/openjij/sampler/sa_sampler.py
+++ b/openjij/sampler/sa_sampler.py
@@ -70,20 +70,14 @@ class SASampler(BaseSampler):
             "beta_max": ["parameters"],
         }
 
-    def __init__(
-        self,
-        beta_min: Optional[float] = None,
-        beta_max: Optional[float] = None,
-        num_sweeps: Optional[int] = None,
-        num_reads: Optional[int] = None,
-        schedule: Optional[list] = None,
-    ):
+    def __init__(self):
 
         # Set default parameters
-        if num_sweeps is None:
-            num_sweeps = 1000
-        if num_reads is None:
-            num_reads = 1
+        num_sweeps = 1000
+        num_reads = 1
+        beta_min = None
+        beta_max = None
+        schedule = None
 
         self._default_params = {
             "beta_min": beta_min,

--- a/openjij/sampler/sqa_sampler.py
+++ b/openjij/sampler/sqa_sampler.py
@@ -53,28 +53,15 @@ class SQASampler(BaseSampler):
             "trotter": ["parameters"],
         }
 
-    @deprecated_alias(iteration="num_reads")
-    def __init__(
-        self,
-        beta: Optional[float] = None,
-        gamma: Optional[float] = None,
-        num_sweeps: Optional[int] = None,
-        num_reads: Optional[int] = None,
-        schedule: Optional[list] = None,
-        trotter: Optional[int] = None,
-    ):
+    def __init__(self):
 
         # Set default parameters
-        if beta is None:
-            beta = 5.0
-        if gamma is None:
-            gamma = 1.0
-        if num_sweeps is None:
-            num_sweeps = 1000
-        if trotter is None:
-            trotter = 4
-        if num_reads is None:
-            num_reads = 1
+        beta = 5.0
+        gamma = 1.0
+        num_sweeps = 1000
+        num_reads = 1
+        schedule = None
+        trotter = 4
 
         self._default_params = {
             "beta": beta,

--- a/tests/test_sampler.py
+++ b/tests/test_sampler.py
@@ -86,9 +86,9 @@ class TestSamplers(unittest.TestCase):
         )
         self._test_response_num(res, num_reads)
 
-        sampler = sampler_cls(num_reads=num_reads)
+        sampler = sampler_cls()
         res = sampler.sample_ising(
-            self.num_ind['h'], self.num_ind['J'],
+            self.num_ind['h'], self.num_ind['J'], num_reads=num_reads
         )
         self._test_response_num(res, num_reads)
 
@@ -119,12 +119,12 @@ class TestSamplers(unittest.TestCase):
         self._test_num_reads(oj.SASampler)
 
         #antiferromagnetic one-dimensional Ising model
-        sampler = oj.SASampler(num_reads=100)
-        res = sampler.sample_ising(self.afih, self.afiJ, seed=1)
+        sampler = oj.SASampler()
+        res = sampler.sample_ising(self.afih, self.afiJ, seed=1, num_reads=100)
         self.assertDictEqual(self.afiground, res.first.sample)
         #antiferromagnetic one-dimensional Ising model
-        sampler = oj.SASampler(num_reads=100)
-        res = sampler.sample_ising(self.afih, self.afiJ, updater='swendsen wang', seed=1)
+        sampler = oj.SASampler()
+        res = sampler.sample_ising(self.afih, self.afiJ, updater='swendsen wang', seed=1, num_reads=100)
         self.assertDictEqual(self.afiground, res.first.sample)
 
     def test_sa_sparse(self):
@@ -153,8 +153,8 @@ class TestSamplers(unittest.TestCase):
         #self._test_num_reads(oj.SASampler)
 
         #antiferromagnetic one-dimensional Ising model
-        sampler = oj.SASampler(num_reads=100)
-        res = sampler.sample_ising(self.afih, self.afiJ, sparse=True, seed=1)
+        sampler = oj.SASampler()
+        res = sampler.sample_ising(self.afih, self.afiJ, sparse=True, seed=1, num_reads=100)
         self.assertDictEqual(self.afiground, res.first.sample)
 
     def test_sa_with_negative_interactions(self):
@@ -203,8 +203,8 @@ class TestSamplers(unittest.TestCase):
         self._test_num_reads(oj.SQASampler)
 
         #antiferromagnetic one-dimensional Ising model
-        sampler = oj.SQASampler(num_reads=100)
-        res = sampler.sample_ising(self.afih, self.afiJ, seed=1)
+        sampler = oj.SQASampler()
+        res = sampler.sample_ising(self.afih, self.afiJ, seed=1, num_reads=100)
         self.assertDictEqual(self.afiground, res.first.sample)
 
     def test_sqa_with_negative_interactions(self):
@@ -247,6 +247,27 @@ class TestSamplers(unittest.TestCase):
             res = sampler.sample_qubo(Q=J)
             self.assertEqual(len(res.first.sample), 100001)
 
+    # Since it is no longer possible to set parameters such as num_reads 
+    # in the constructor of sampler class from this version, the following test was added.
+    # This test can be removed from the next version 
+    # because this will be the specification from now on.
+    def test_error_handling(self):
+        with self.assertRaises(TypeError):
+            oj.SASampler(num_reads=100)
+        with self.assertRaises(TypeError):
+            oj.SASampler(num_sweeps=100)
+        with self.assertRaises(TypeError):
+            oj.SASampler(beta_min=10)
+        with self.assertRaises(TypeError):
+            oj.SASampler(beta_max=10)
+        with self.assertRaises(TypeError):
+            oj.SQASampler(num_reads=100)
+        with self.assertRaises(TypeError):
+            oj.SQASampler(num_sweeps=100)
+        with self.assertRaises(TypeError):
+            oj.SQASampler(beta=10)
+        with self.assertRaises(TypeError):
+            oj.SQASampler(trotter=10)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Changes

Removed the option to set parameters such as num_reads from the constructors of SASampler and SQASampler.
We also added a test to confirm that it cannot be set, but this will be removed in the next update as it will become a specification in the future.

## Examples
After this changes,
```
>>> import openjij as oj
>>> oj.SASampler(num_reads=10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() got an unexpected keyword argument 'num_reads'
```
```
>>> oj.SQASampler(num_reads=10)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: __init__() got an unexpected keyword argument 'num_reads'
```
