### PR TITLE
Fix CI Error in OpenJij

### DIFF
--- a/.github/workflows/ci-test-cpp.yml
+++ b/.github/workflows/ci-test-cpp.yml
@@ -165,17 +165,18 @@ jobs:
       working-directory: build
       run: |
         gcov  --object-directory ./tests/CMakeFiles/openjij_test.dir -p -l -b ./tests/CMakeFiles/cxxjij_test.dir/cxxtest.cpp.gcda
-    - name: Run gcov
-      if: ${{ matrix.os == 'ubuntu-latest'}}
-      shell: bash
-      run: |
-        gcov   --object-directory ./build/tests/CMakeFiles/openjij_test.dir -p -l -b ./build/tests/CMakeFiles/cxxjij_test.dir/cxxtest.cpp.gcda
-    - name: Run gcov
-      if: ${{ matrix.os == 'ubuntu-latest'}}
-      shell: bash
-      run: |
-        cd build/tests/CMakeFiles/cxxjij_test.dir
-        gcov  --object-directory ./  -p -l -b cxxtest.cpp.gcda
+    # TODO: Skip as currently (2025/2/27) it is not working
+    #- name: Run gcov
+    #  if: ${{ matrix.os == 'ubuntu-latest'}}
+    #  shell: bash
+    #  run: |
+    #    gcov   --object-directory ./build/tests/CMakeFiles/openjij_test.dir -p -l -b ./build/tests/CMakeFiles/cxxjij_test.dir/cxxtest.cpp.gcda
+    #- name: Run gcov
+    #  if: ${{ matrix.os == 'ubuntu-latest'}}
+    #  shell: bash
+    #  run: |
+    #    cd build/tests/CMakeFiles/cxxjij_test.dir
+    #    gcov  --object-directory ./  -p -l -b cxxtest.cpp.gcda
     - name: du -a 
       shell: bash
       if: always()

--- a/.github/workflows/ci-test-cpp.yml
+++ b/.github/workflows/ci-test-cpp.yml
@@ -159,12 +159,13 @@ jobs:
         --extra-verbose
         --parallel
         --schedule-random
-    - name: Run gcov
-      if: ${{ matrix.os == 'ubuntu-latest'}}
-      shell: bash
-      working-directory: build
-      run: |
-        gcov  --object-directory ./tests/CMakeFiles/openjij_test.dir -p -l -b ./tests/CMakeFiles/cxxjij_test.dir/cxxtest.cpp.gcda
+    # TODO: Skip as currently (2025/2/27) it is not working
+    #- name: Run gcov
+    #  if: ${{ matrix.os == 'ubuntu-latest'}}
+    #  shell: bash
+    #  working-directory: build
+    #  run: |
+    #    gcov  --object-directory ./tests/CMakeFiles/openjij_test.dir -p -l -b ./tests/CMakeFiles/cxxjij_test.dir/cxxtest.cpp.gcda
     # TODO: Skip as currently (2025/2/27) it is not working
     #- name: Run gcov
     #  if: ${{ matrix.os == 'ubuntu-latest'}}

--- a/.github/workflows/ci-test-python.yaml
+++ b/.github/workflows/ci-test-python.yaml
@@ -174,7 +174,7 @@ jobs:
       shell: bash
       run: |
         set -eux
-        python setup.py --build-type Debug test 
+        pytest 
     - name: Generate
       shell: bash
       run: |

--- a/cmake/FindLcov.cmake
+++ b/cmake/FindLcov.cmake
@@ -64,19 +64,6 @@ if (NOT CPPFILT_BIN STREQUAL "")
 	set(GENHTML_CPPFILT_FLAG "--demangle-cpp")
 endif (NOT CPPFILT_BIN STREQUAL "")
 
-# enable ignore-errors mismatch flag for geninfo, to bypass line number mismatch errors
-if (GENINFO_BIN AND NOT DEFINED GENINFO_IGNORE_ERRORS_FLAG)
-	set(FLAG "")
-	execute_process(COMMAND ${GENINFO_BIN} --help OUTPUT_VARIABLE GENINFO_HELP)
-	string(REGEX MATCH "ignore-errors" GENINFO_RES "${GENINFO_HELP}")
-	if (GENINFO_RES)
-		set(FLAG "--ignore-errors mismatch")
-	endif ()
-
-	set(GENINFO_IGNORE_ERRORS_FLAG "${FLAG}"
-		CACHE STRING "Geninfo flag to ignore line number mismatch errors.")
-endif ()
-
 # enable no-external flag for lcov, if available.
 if (GENINFO_BIN AND NOT DEFINED GENINFO_EXTERN_FLAG)
 	set(FLAG "")
@@ -89,6 +76,20 @@ if (GENINFO_BIN AND NOT DEFINED GENINFO_EXTERN_FLAG)
 	set(GENINFO_EXTERN_FLAG "${FLAG}"
 		CACHE STRING "Geninfo flag to exclude system sources.")
 endif ()
+
+# enable ignore-errors mismatch flag for geninfo, to bypass line number mismatch errors
+if (GENINFO_BIN AND NOT DEFINED GENINFO_IGNORE_ERRORS_FLAG)
+	set(FLAG "")
+	execute_process(COMMAND ${GENINFO_BIN} --help OUTPUT_VARIABLE GENINFO_HELP)
+	string(REGEX MATCH "ignore-errors" GENINFO_RES "${GENINFO_HELP}")
+	if (GENINFO_RES)
+		set(FLAG "--ignore-errors mismatch")
+	endif ()
+
+	set(GENINFO_IGNORE_ERRORS_FLAG ${FLAG}
+		CACHE STRING "Geninfo flag to ignore line number mismatch errors.")
+endif ()
+
 
 # If Lcov was not found, exit module now.
 if (NOT LCOV_FOUND)

--- a/cmake/FindLcov.cmake
+++ b/cmake/FindLcov.cmake
@@ -83,10 +83,10 @@ if (GENINFO_BIN AND NOT DEFINED GENINFO_IGNORE_ERRORS_FLAG)
 	execute_process(COMMAND ${GENINFO_BIN} --help OUTPUT_VARIABLE GENINFO_HELP)
 	string(REGEX MATCH "ignore-errors" GENINFO_RES "${GENINFO_HELP}")
 	if (GENINFO_RES)
-		set(FLAG "--ignore-errors mismatch")
+		set(FLAG --ignore-errors mismatch)
 	endif ()
 
-	set(GENINFO_IGNORE_ERRORS_FLAG ${FLAG}
+	set(GENINFO_IGNORE_ERRORS_FLAG "${FLAG}"
 		CACHE STRING "Geninfo flag to ignore line number mismatch errors.")
 endif ()
 

--- a/cmake/FindLcov.cmake
+++ b/cmake/FindLcov.cmake
@@ -64,19 +64,6 @@ if (NOT CPPFILT_BIN STREQUAL "")
 	set(GENHTML_CPPFILT_FLAG "--demangle-cpp")
 endif (NOT CPPFILT_BIN STREQUAL "")
 
-# enable no-external flag for lcov, if available.
-if (GENINFO_BIN AND NOT DEFINED GENINFO_EXTERN_FLAG)
-	set(FLAG "")
-	execute_process(COMMAND ${GENINFO_BIN} --help OUTPUT_VARIABLE GENINFO_HELP)
-	string(REGEX MATCH "external" GENINFO_RES "${GENINFO_HELP}")
-	if (GENINFO_RES)
-		set(FLAG "--no-external")
-	endif ()
-
-	set(GENINFO_EXTERN_FLAG "${FLAG}"
-		CACHE STRING "Geninfo flag to exclude system sources.")
-endif ()
-
 # enable ignore-errors mismatch flag for geninfo, to bypass line number mismatch errors
 if (GENINFO_BIN AND NOT DEFINED GENINFO_IGNORE_ERRORS_FLAG)
 	set(FLAG "")
@@ -88,6 +75,19 @@ if (GENINFO_BIN AND NOT DEFINED GENINFO_IGNORE_ERRORS_FLAG)
 
 	set(GENINFO_IGNORE_ERRORS_FLAG "${FLAG}"
 		CACHE STRING "Geninfo flag to ignore line number mismatch errors.")
+endif ()
+
+# enable no-external flag for lcov, if available.
+if (GENINFO_BIN AND NOT DEFINED GENINFO_EXTERN_FLAG)
+	set(FLAG "")
+	execute_process(COMMAND ${GENINFO_BIN} --help OUTPUT_VARIABLE GENINFO_HELP)
+	string(REGEX MATCH "external" GENINFO_RES "${GENINFO_HELP}")
+	if (GENINFO_RES)
+		set(FLAG "--no-external")
+	endif ()
+
+	set(GENINFO_EXTERN_FLAG "${FLAG}"
+		CACHE STRING "Geninfo flag to exclude system sources.")
 endif ()
 
 # If Lcov was not found, exit module now.

--- a/cmake/FindLcov.cmake
+++ b/cmake/FindLcov.cmake
@@ -77,6 +77,19 @@ if (GENINFO_BIN AND NOT DEFINED GENINFO_EXTERN_FLAG)
 		CACHE STRING "Geninfo flag to exclude system sources.")
 endif ()
 
+# enable ignore-errors mismatch flag for geninfo, to bypass line number mismatch errors
+if (GENINFO_BIN AND NOT DEFINED GENINFO_IGNORE_ERRORS_FLAG)
+	set(FLAG "")
+	execute_process(COMMAND ${GENINFO_BIN} --help OUTPUT_VARIABLE GENINFO_HELP)
+	string(REGEX MATCH "ignore-errors" GENINFO_RES "${GENINFO_HELP}")
+	if (GENINFO_RES)
+		set(FLAG "--ignore-errors mismatch")
+	endif ()
+
+	set(GENINFO_IGNORE_ERRORS_FLAG "${FLAG}"
+		CACHE STRING "Geninfo flag to ignore line number mismatch errors.")
+endif ()
+
 # If Lcov was not found, exit module now.
 if (NOT LCOV_FOUND)
 	return()
@@ -171,7 +184,7 @@ function (lcov_capture_initial_tgt TNAME)
 		add_custom_command(OUTPUT ${OUTFILE} COMMAND ${GCOV_ENV} ${GENINFO_BIN}
 				--quiet --base-directory ${PROJECT_SOURCE_DIR} --initial
 				--gcov-tool ${GCOV_BIN} --output-filename ${OUTFILE}
-				${GENINFO_EXTERN_FLAG} ${TDIR}/${FILE}.gcno
+				${GENINFO_EXTERN_FLAG} ${GENINFO_IGNORE_ERRORS_FLAG} ${TDIR}/${FILE}.gcno
 			DEPENDS ${TNAME}
 			COMMENT "Capturing initial coverage data for ${FILE}"
 		)
@@ -271,7 +284,7 @@ function (lcov_capture_tgt TNAME)
 			COMMAND test -s "${TDIR}/${FILE}.gcda"
 				&& ${GCOV_ENV} ${GENINFO_BIN} --quiet --base-directory
 					${PROJECT_SOURCE_DIR} --gcov-tool ${GCOV_BIN}
-					--output-filename ${OUTFILE} ${GENINFO_EXTERN_FLAG}
+					--output-filename ${OUTFILE} ${GENINFO_EXTERN_FLAG} ${GENINFO_IGNORE_ERRORS_FLAG}
 					${TDIR}/${FILE}.gcda
 				|| cp ${OUTFILE}.init ${OUTFILE}
 			DEPENDS ${TNAME} ${TNAME}-capture-init "${TDIR}/${FILE}.gcda"

--- a/setup.cfg
+++ b/setup.cfg
@@ -58,7 +58,9 @@ install_requires =
     requests >= 2.28.0, < 2.32.0
     jij-cimod >= 1.6.0, < 1.7.0
     typing-extensions >= 4.2.0
-tests_require =
+
+[options.extras_require]
+test =
     pytest
     pytest-mock
     pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,18 @@ try:
 except ImportError:
     from setuptools import setup
 
+setup_requires = [
+    "numpy",
+    "pybind11",
+    "cmake > 3.20",
+    "scikit-build > 0.16.0"
+]
+
+if any(arg in sys.argv for arg in ("pytest", "test")):
+    setup_requires.append("pytest-runner")
+
 setup(
+    setup_requires=setup_requires,
     packages=[
         "openjij",
         "openjij.model",

--- a/setup.py
+++ b/setup.py
@@ -19,24 +19,7 @@ try:
 except ImportError:
     from setuptools import setup
 
-setup_requires = [
-    "numpy",
-    "pybind11",
-    "cmake > 3.20",
-    "scikit-build > 0.16.0"
-]
-
-if any(arg in sys.argv for arg in ("pytest", "test")):
-    setup_requires.append("pytest-runner")
-
 setup(
-    setup_requires=setup_requires,
-    packages=[
-        "openjij",
-        "openjij.model",
-        "openjij.sampler",
-        "openjij.utils",
-    ],
     cmake_install_dir="openjij",
     include_package_data=False,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ if any(arg in sys.argv for arg in ("pytest", "test")):
     setup_requires.append("pytest-runner")
 
 setup(
-    extras_require=setup_requires,
+    setup_requires=setup_requires,
     packages=[
         "openjij",
         "openjij.model",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,12 @@ except ImportError:
     from setuptools import setup
 
 setup(
+    packages=[
+        "openjij",
+        "openjij.model",
+        "openjij.sampler",
+        "openjij.utils",
+    ],
     cmake_install_dir="openjij",
     include_package_data=False,
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,18 @@ try:
 except ImportError:
     from setuptools import setup
 
+setup_requires = [
+    "numpy",
+    "pybind11",
+    "cmake > 3.20",
+    "scikit-build > 0.16.0"
+]
+
+if any(arg in sys.argv for arg in ("pytest", "test")):
+    setup_requires.append("pytest-runner")
+
 setup(
+    extras_require=setup_requires,
     packages=[
         "openjij",
         "openjij.model",

--- a/setup.py
+++ b/setup.py
@@ -19,18 +19,7 @@ try:
 except ImportError:
     from setuptools import setup
 
-setup_requires = [
-    "numpy",
-    "pybind11",
-    "cmake > 3.20",
-    "scikit-build > 0.16.0"
-]
-
-if any(arg in sys.argv for arg in ("pytest", "test")):
-    setup_requires.append("pytest-runner")
-
 setup(
-    setup_requires=setup_requires,
     packages=[
         "openjij",
         "openjij.model",


### PR DESCRIPTION
## Changes
* Fix geninfo line number mismatch error
  - We fixed a CI error that's occurring during the code coverage data collection step for the C++ tests. The error is happening with the geninfo tool and indicates a line number mismatch in the C++ hpp file.
  - This appears to be a bug of gcc 14 as indicated in the issue https://github.com/linux-test-project/lcov/issues/296. Since [GitHub Actions set the ubuntu-latest to ubuntu-24.04](https://github.com/actions/runner-images/issues/10636), the default compiler is replaced with gcc 14.
  - We fixed the error by adding `--ignore-errors mismatch` to `geninfo`.
  - The following process using gcov is temporarily skipped.

* Modify `setup.cfg` and test command
  - modify `setup.cfg` by replacing `tests_require` with `extras_require`.
  - replace `python setup.py test` to `pytest`.
## Related issue

- https://github.com/linux-test-project/lcov/issues/296
