### PR TITLE
Fix Eigen3 detection for 5.x compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ endif()
 
 find_package(Eigen3 CONFIG)
 
-if(TARGET Eigen3::Eigen)
+if(EIGEN3_FOUND OR TARGET Eigen3::Eigen)
   message(STATUS "Skip Download eigen3")
 else()
   message(STATUS "Downlod eigen3")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ find_package(Eigen3 CONFIG)
 if(TARGET Eigen3::Eigen OR EIGEN3_FOUND)
   message(STATUS "Skip Download eigen3")
 else()
-  message(STATUS "Downlod eigen3")
+  message(STATUS "Download eigen3")
   include(external/eigen.cmake)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,12 +157,12 @@ endif()
 
 find_package(Eigen3 CONFIG)
 
-if(EIGEN3_FOUND)
+if(TARGET Eigen3::Eigen)
   message(STATUS "Skip Download eigen3")
-else() 
+else()
   message(STATUS "Downlod eigen3")
   include(external/eigen.cmake)
-endif() 
+endif()
 
 find_package(nlohmann_json CONFIG)
 if(TARGET nlohmann_json::nlohmann_json)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ endif()
 
 find_package(Eigen3 CONFIG)
 
-if(EIGEN3_FOUND OR TARGET Eigen3::Eigen)
+if(TARGET Eigen3::Eigen OR EIGEN3_FOUND)
   message(STATUS "Skip Download eigen3")
 else()
   message(STATUS "Downlod eigen3")

--- a/external/cimod.cmake
+++ b/external/cimod.cmake
@@ -35,7 +35,7 @@ if(NOT cimod_POPULATED)
     # cimod v1.7.2 checks EIGEN3_FOUND after find_package(Eigen3 CONFIG),
     # but Eigen3 5.x no longer sets EIGEN3_FOUND (removed in commit f2984cd0).
     # Bridge the gap by setting it when the imported target exists.
-    if(NOT EIGEN3_FOUND AND TARGET Eigen3::Eigen)
+    if(TARGET Eigen3::Eigen AND NOT EIGEN3_FOUND)
         set(EIGEN3_FOUND ON)
     endif()
     add_subdirectory(${cimod_SOURCE_DIR} ${cimod_BINARY_DIR} EXCLUDE_FROM_ALL)

--- a/external/cimod.cmake
+++ b/external/cimod.cmake
@@ -32,6 +32,12 @@ FetchContent_Declare(
 FetchContent_GetProperties(cimod)
 if(NOT cimod_POPULATED)
     FetchContent_Populate(cimod)
+    # cimod v1.7.2 checks EIGEN3_FOUND after find_package(Eigen3 CONFIG),
+    # but Eigen3 5.x no longer sets EIGEN3_FOUND (removed in commit f2984cd0).
+    # Bridge the gap by setting it when the imported target exists.
+    if(TARGET Eigen3::Eigen)
+        set(EIGEN3_FOUND ON)
+    endif()
     add_subdirectory(${cimod_SOURCE_DIR} ${cimod_BINARY_DIR} EXCLUDE_FROM_ALL)
 endif()
 

--- a/external/cimod.cmake
+++ b/external/cimod.cmake
@@ -35,7 +35,7 @@ if(NOT cimod_POPULATED)
     # cimod v1.7.2 checks EIGEN3_FOUND after find_package(Eigen3 CONFIG),
     # but Eigen3 5.x no longer sets EIGEN3_FOUND (removed in commit f2984cd0).
     # Bridge the gap by setting it when the imported target exists.
-    if(TARGET Eigen3::Eigen)
+    if(NOT EIGEN3_FOUND AND TARGET Eigen3::Eigen)
         set(EIGEN3_FOUND ON)
     endif()
     add_subdirectory(${cimod_SOURCE_DIR} ${cimod_BINARY_DIR} EXCLUDE_FROM_ALL)


### PR DESCRIPTION
## Summary

Eigen3 5.x で `EIGEN3_FOUND`（全大文字）が設定されなくなった問題を修正。

## 問題

`find_package(Eigen3 CONFIG)` 後に `EIGEN3_FOUND` で検出判定していたが、Eigen3 5.x（brew / vcpkg で提供）ではこの変数が設定されず、既にインストール済みの Eigen3 を「見つからない」と誤判定 → FetchContent で再取得 → `Eigen3::Eigen` ターゲットの二重定義エラーが発生。

## 原因

Eigen3 のコミット [f2984cd0](https://gitlab.com/libeigen/eigen/-/commit/f2984cd0778dd0a1d7e74216d826eaff2bc6bfab)（"cmake: remove deprecated package config variables"）で `Eigen3Config.cmake` からレガシー変数群が削除された。

- CMake の `find_package(Eigen3 CONFIG)` はパッケージ名そのままの `Eigen3_FOUND` を自動設定する
- 全大文字の `EIGEN3_FOUND` は Config ファイル自身が `set()` しない限り設定されない（CMake の変数名は大文字小文字を区別する）
- Eigen3 3.4.x では `set(EIGEN3_FOUND 1)` が明示的に記述されていたが、5.0.x で削除された

### CI 環境での確認結果

| 環境 | Eigen3 | `EIGEN3_FOUND` | `Eigen3_FOUND` | `TARGET Eigen3::Eigen` |
|---|---|---|---|---|
| Ubuntu (apt) | 3.4.0 | `1` | `1` | YES |
| macOS (brew) | 5.0.1 | 空 | `1` | YES |
| Windows (vcpkg) | 5.0.1 | 空 | `1` | YES |

## 修正内容

- **CMakeLists.txt**: `if(EIGEN3_FOUND)` → `if(TARGET Eigen3::Eigen OR EIGEN3_FOUND)` に変更。`TARGET` チェックは Eigen3 のバージョンに依存せず、インポートターゲットの存在だけで判定するため安定して動作する。`EIGEN3_FOUND` も後方互換性のために残している。
- **external/cimod.cmake**: cimod v1.7.2 は内部で `EIGEN3_FOUND` をチェックしているため、`add_subdirectory` の前に `if(TARGET Eigen3::Eigen AND NOT EIGEN3_FOUND) set(EIGEN3_FOUND ON)` で変数を補完するワークアラウンドを追加。

## cimod 側の対応

cimod 本体の `CMakeLists.txt` でも同様に `IF(EIGEN3_FOUND)` → `IF(TARGET Eigen3::Eigen OR EIGEN3_FOUND)` に修正するPRを作成済み。リリースされれば OpenJij 側のワークアラウンド（`set(EIGEN3_FOUND ON)`）は不要になる。

- https://github.com/Jij-Inc/cimod/pull/225

🤖 Generated with [Claude Code](https://claude.com/claude-code)