### PR TITLE
macOS wheel で Homebrew の Eigen と nlohmann-json を使う

### DIFF
--- a/.github/workflows/build_and_upload.yaml
+++ b/.github/workflows/build_and_upload.yaml
@@ -188,6 +188,11 @@ jobs:
             llvm_openmp_sha256: ccbaad6bbc88f135ab849bc36af5fa6eda36a9ed18ce6f58e3dde3d11784c156
     steps:
       - uses: actions/checkout@v5
+      - name: Install Dependency
+        shell: bash
+        run: |
+          set -eux
+          brew install eigen nlohmann-json
       - name: Download conda-forge llvm-openmp
         shell: bash
         run: |
@@ -237,8 +242,7 @@ jobs:
             CMAKE_ARGS='-DCMAKE_PREFIX_PATH=${{ github.workspace }}/.vendor/llvm-openmp/prefix
             -DOpenMP_ROOT=${{ github.workspace }}/.vendor/llvm-openmp/prefix
             -DCMAKE_INSTALL_RPATH=${{ github.workspace }}/.vendor/llvm-openmp/prefix/lib
-            -DOPENJIJ_REQUIRE_OPENMP=ON
-            -DCMAKE_IGNORE_PREFIX_PATH=/opt/homebrew;/usr/local'
+            -DOPENJIJ_REQUIRE_OPENMP=ON'
       - uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.artifact}}


### PR DESCRIPTION
## 概要

`CMAKE_IGNORE_PREFIX_PATH=/opt/homebrew;/usr/local` は、OpenMP 以外の依存関係の探索にも影響する。

macOS wheel job に `brew install eigen nlohmann-json` を戻し、この指定を削除する。`libomp` は Homebrew からインストールせず、引き続き conda-forge の `llvm-openmp` を使用する。

## 確認したこと

- macOS `x86_64` / `arm64` のwheel buildが成功した
- Eigenとnlohmann-jsonはHomebrew、OpenMPはconda-forgeから使われることを確認した
- 全macOS wheelが同梱した`libomp.dylib`を参照することを確認した
- `cp312 arm64` wheelでimportと`SASampler`の実行を確認した